### PR TITLE
Word for Word Changes

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -248,6 +248,7 @@
 [extensions]: {{ site.api_url | absolute_url }}/extension/
 [text-granularity]: {{ site.api_url | absolute_url }}/extension/text-granularity/
 [navPlace]: {{ site.api_url | absolute_url }}/extension/navplace/
+[georeference]: {{ site.api_url | absolute_url }}/extension/georef/
 [registry]: {{ site.api_url | absolute_url }}/registry/ "IIIF Extension Registry"
 [registry-activity-streams]: https://registry.iiif.io/ "IIIF Registry of Activity Streams"
 [registry-motivations]: {{ site.api_url | absolute_url }}/registry/motivations/

--- a/source/extension/georef/1/context.json
+++ b/source/extension/georef/1/context.json
@@ -68,7 +68,7 @@
           "@container": "@list"
         },
         "resourceCoords": {
-          "@id": "iiif_georef:pixel_coords",
+          "@id": "iiif_georef:resourceCoords",
           "@container": "@list",
           "@type": "xsd:float"
         }

--- a/source/extension/georef/1/context.json
+++ b/source/extension/georef/1/context.json
@@ -1,31 +1,21 @@
 {
   "@context": {
     "@version": 1.1,
-    "geo": "https://purl.org/geojson/vocab#",
+    "geojson": "https://purl.org/geojson/vocab#",
     "iiif_prezi": "http://iiif.io/api/presentation/3#",
     "iiif_image": "http://iiif.io/api/image/3#",
+    "iiif_georef": "http://iiif.io/api/extension/georef/vocab/georef-terms.md#",
     "oa": "http://www.w3.org/ns/oa#",
-    "sc": "http://iiif.io/api/presentation/2#",
     "as": "http://www.w3.org/ns/activitystreams#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "iiif_georef": "http://iiif.io/api/extension/georef/vocab/georef-terms.md#",
     "id": "@id",
     "type": "@type",
-<<<<<<< HEAD
     "georeferencing": "iiif_georef:georeferencing",
     "transformation":{
       "@id": "iiif_georef:transformation",
       "@context": {
         "options":{
           "@id": "iiif_georef:options",
-=======
-    "georeferencing": "proto:georeferencing",
-    "transformation": {
-      "@id": "proto:transformation",
-      "@context": {
-        "options": {
-          "@id": "proto:options",
->>>>>>> georef
           "@context": {
             "order": {
               "@id": "iiif_georef:order",
@@ -55,7 +45,7 @@
     "region": "https://iiif.io/api/image/3.0/#41-region",
     "size": "https://iiif.io/api/image/3.0/#42-size",
     "properties": {
-      "@id": "geo:properties",
+      "@id": "geojson:properties",
       "@context": {
         "label": {
           "@id": "rdfs:label",
@@ -77,11 +67,7 @@
           "@container": "@list"
         },
         "resourceCoords": {
-<<<<<<< HEAD
           "@id": "iiif_georef:resourceCoords",
-=======
-          "@id": "proto:resourceCoords",
->>>>>>> georef
           "@container": "@list",
           "@type": "xsd:float"
         }

--- a/source/extension/georef/1/context.json
+++ b/source/extension/georef/1/context.json
@@ -8,26 +8,26 @@
     "sc": "http://iiif.io/api/presentation/2#",
     "as": "http://www.w3.org/ns/activitystreams#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "proto": "http://iiif.io/api/extension/georef/vocab/georef-terms.md#",
+    "iiif_georef": "http://iiif.io/api/extension/georef/vocab/georef-terms.md#",
     "id": "@id",
     "type": "@type",
-    "georeferencing": "proto:georeferencing",
+    "georeferencing": "iiif_georef:georeferencing",
     "transformation":{
-      "@id": "proto:transformation",
+      "@id": "iiif_georef:transformation",
       "@context": {
         "options":{
-          "@id": "proto:options",
+          "@id": "iiif_georef:options",
           "@context": {
             "order": {
-              "@id": "proto:order",
+              "@id": "iiif_georef:order",
               "@type": "xsd:integer"
             }  
           }
         }
       }
     },
-    "polynomial": "proto:polynomial",
-    "thinPlateSpline": "proto:thinPlateSpline",
+    "polynomial": "iiif_georef:polynomial",
+    "thinPlateSpline": "iiif_georef:thinPlateSpline",
     "body": {
       "@context": [
         "https://geojson.org/geojson-ld/geojson-context.jsonld",
@@ -68,7 +68,7 @@
           "@container": "@list"
         },
         "resourceCoords": {
-          "@id": "proto:pixel_coords",
+          "@id": "iiif_georef:pixel_coords",
           "@container": "@list",
           "@type": "xsd:float"
         }

--- a/source/extension/georef/index.md
+++ b/source/extension/georef/index.md
@@ -36,7 +36,7 @@ Further, the following use cases are not in scope:
 - Adding IIIF resources as map layers to dynamic web maps or in GIS applications. Based on georeference data, clients can transform IIIF resources by scaling, skewing, rotating and stretching them. This process, also called _warping_, can be carried out through various methods.
 - The previous use case also supports stitching together multiple map sheets, each represented by a single IIIF resource, to form a composite map. Alternatively, it can be used to compare different versions of the same map or a collection of maps of the same area.
 - Geospatial exploration of IIIF resources. Georeference data can be used to compute the geospatial areas depicted on IIIF resources. This enables geospatial indexing and harvesting by geospatial search engines.
-- The same method can be used to convert Web Annotations to geographic formats such as GeoJSON, and vice versa. This can be used to display Web Annotations as vectors in a map interface or to paint geographic data on a Canvas from its connected Annotations.
+- The same method can be used to convert Web Annotations to geographic formats such as GeoJSON, and vice versa. This can be used to display Web Annotations as vectors in a map interface or to paint geographic data onto a Canvas from its connected Annotations.
 - Calculating the scale (in pixels per unit of length) and orientation (compass direction) of IIIF resources. This can be used to improve user experiences when viewing IIIF resources or for indexing.
 - Converting IIIF resources to a variety of raster map formats such as GeoTIFF and XYZ map tiles. This allows resources to be used in conventional GIS software.
 

--- a/source/extension/georef/index.md
+++ b/source/extension/georef/index.md
@@ -15,7 +15,7 @@ Changes will be tracked within the document.
 
 ## 1. Introduction
 
-This document describes a way to store the metadata needed to georeference a IIIF resource in a _Georeference Annotation_. Georeference Annotations can be used to convert images such as digitized maps and aerial photographs to geospatial assets.
+This document describes a way to store the metadata needed to georeference a IIIF resource in a _Georeference Annotation_. Georeference Annotations can be used to convert images such as digitized maps and aerial photographs into geospatial assets.
 
 The [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) has the capability to support complex Web Annotations which can provide detailed and specific information regarding IIIF resources. You can see various use cases which implement such Web Annotations in the [IIIF Cookbook](https://iiif.io/api/cookbook/). Through the work of the [IIIF Maps Community Group](https://iiif.io/community/groups/maps/) and [IIIF Maps TSG](https://iiif.io/community/groups/maps-tsg/), a commonality of techniques to georeference IIIF Canvases and Images in the context of a global map became evident, and a desire to have standards and best practices for georeferencing became known.
 
@@ -23,20 +23,20 @@ The [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) has the capab
 
 This document will supply vocabulary and a linked data 1.1 context allowing for a JSON-LD pattern by which to extend Web Annotation and the IIIF Presentation API to support georeferencing. This pattern promotes interoperability for georeferenced maps across different georeferencing platforms, even those which focus on georeferencing for a specific use case such as those listed in the [Motivating Use Cases](#12-motivating-use-cases) section below.
 
-The [existing GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946) is adopted for its linked data vocabulary and context for geographic coordinates. This means coordinates are expressed through the [WGS84](http://www.w3.org/2003/01/geo/wgs84_pos) coordinate reference system. As such, expressing the location of extraterrestrial entities is not supported by this technique.
+The [existing GeoJSON format](https://datatracker.ietf.org/doc/html/rfc7946) is adopted for its linked data vocabulary and context for geographic coordinates. This means coordinates are expressed through the [WGS84](http://www.w3.org/2003/01/geo/wgs84_pos) coordinate reference system. As such, expressing the location of extraterrestrial entities is not supported by this technique.
 
 Further, the following use cases are not in scope:
 
-- Geotagging of (non-aerial) photographs. This extension is aimed at georeferencing cartographic IIIF resources containing two-dimensional representations of the three-dimensional surface of the globe. Usage may extent to other representations that can be mapped to geospatial coordinates, such as orthographic plan projections or vertical aerial photographs. Geotagging photographs is out of scope because this requires a different set of datapoints and relates to other use cases. Please refer to the [navPlace Extension](https://iiif.io/api/extension/navplace/) for an alternative solution.
-- Georeferencing altitude or elevation. Although the GeoJSON specifications support a third position element indicating the "height in meters above or below the WGS 84 reference ellipsoid", this is not included in the extension. Adding a third position element will however not result in an invalid Georeference Annotation, and it might be supported in future versions of the extension.
-- Specifying the original map projection and related coordinate reference system (CRS) of a IIIF resource. When selecting a transformation method in order to warp a map, it can be useful to know the original map projection of a IIIF resource, such as Mercator or Lambert. Including this in the Georeference Annotation would require a complex taxonomy, which is out of scope. A solution is to include this information in the metadata of the IIIF Manifest, or in a machine readable format referenced through the [seeAlso](https://iiif.io/api/presentation/3.0/#seealso) property.
+- Geotagging of (non-aerial) photographs. This extension is aimed at georeferencing cartographic IIIF resources containing two-dimensional representations of the three-dimensional surface of the globe. Usage may extentd to other representations that can be mapped to geospatial coordinates, such as orthographic plan projections or vertical aerial photographs. Geotagging photographs is out of scope because this requires a different set of data points and relates to other use cases. Please refer to the [navPlace Extension](https://iiif.io/api/extension/navplace/) for an alternative solution.
+- Georeferencing altitude or elevation. The GeoJSON format [supports a third position element](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1) indicating the "height in meters above or below the WGS84 reference ellipsoid". Adding this position element will not result in an invalid Georeference Annotation, but this extension will not cover any use of this element. It may be utilized in future versions of this extension.
+- Specifying the original map projection and related coordinate reference system (CRS) of a IIIF resource. When selecting a transformation method to warp a map, it can be useful to know the original map projection of a IIIF resource, such as Mercator or Lambert. Including this in the Georeference Annotation would require a complex taxonomy, which is out of scope. A solution is to include this information in the metadata of the IIIF Manifest, or in a machine readable format referenced through the [seeAlso](https://iiif.io/api/presentation/3.0/#seealso) property.
 
 ### 1.2 Motivating Use Cases
 
 - Adding IIIF resources as map layers to dynamic web maps or in GIS applications. Based on georeference data, clients can transform IIIF resources by scaling, skewing, rotating and stretching them. This process, also called _warping_, can be carried out through various methods.
 - The previous use case also supports stitching together multiple map sheets, each represented by a single IIIF resource, to form a composite map. Alternatively, it can be used to compare different versions of the same map or a collection of maps of the same area.
 - Geospatial exploration of IIIF resources. Georeference data can be used to compute the geospatial areas depicted on IIIF resources. This enables geospatial indexing and harvesting by geospatial search engines.
-- The same method can be used to convert IIIF Web Annotations to geographic formats such as GeoJSON, and vice versa. This can be used to display IIIF annotations as vectors in a map interface or to paint geographic data as IIIF annotations on a Canvas.
+- The same method can be used to convert Web Annotations to geographic formats such as GeoJSON, and vice versa. This can be used to display Web Annotations as vectors in a map interface or to paint geographic data on a Canvas from its connected Annotations.
 - Calculating the scale (in pixels per unit of length) and orientation (compass direction) of IIIF resources. This can be used to improve user experiences when viewing IIIF resources or for indexing.
 - Converting IIIF resources to a variety of raster map formats such as GeoTIFF and XYZ map tiles. This allows resources to be used in conventional GIS software.
 
@@ -56,15 +56,15 @@ The key words _MUST_, _MUST NOT_, _REQUIRED_, _SHALL_, _SHALL NOT_, _SHOULD_, _S
 
 ### 2.1 Georeferencing
 
-Georeferencing is the process of mapping internal coordinates of an image to geographic coordinates. For the purposes of this extension, references to _IIIF resource_ equates to a IIIF Presentation API [Canvas](https://iiif.io/api/presentation/3.0/#53-canvas) or [Image Service](https://iiif.io/api/presentation/3.0/#service). To qualify for georeferencing, the IIIF resource must include one or more regions that can be mapped to geographic coordinates such as cartographic material, aerial photographs, archaeological drawings, and building plans. In this specification, each of these regions is called a _map_.
+Georeferencing is the process of mapping the internal coordinates of an image to geographic coordinates. For the purposes of this extension, references to _IIIF resource_ equate to a IIIF Presentation API [Canvas](https://iiif.io/api/presentation/3.0/#53-canvas) or [Image Service](https://iiif.io/api/presentation/3.0/#service). To qualify for georeferencing, the IIIF resource must include one or more regions that can be mapped to geographic coordinates such as cartographic material, aerial photographs, archaeological drawings, and building plans. In this extension, each of these regions is called a _map_.
 
-In order to be georeferenced with a single Georeference Annotation, the image information of the IIIF resource must be accessible with a single, continuous cartesian coordinate system. This is why a Georeferencing Annotation can be used to georeference a Canvas or Images Service, but not a [Manifest](https://iiif.io/api/presentation/3.0/#52-manifest) or [Range](https://iiif.io/api/presentation/3.0/#54-range). To georeference a Manifest or Range, multiple Georeference Annotations are needed, one for each Canvas or Image Service in the Manifest or Range.
+To be georeferenced with a single Georeference Annotation the image information of the IIIF resource must be accessible with a single, continuous cartesian coordinate system. This is why a Georeferencing Annotation can be used to georeference a Canvas or Image Service, but not a [Manifest](https://iiif.io/api/presentation/3.0/#52-manifest) or [Range](https://iiif.io/api/presentation/3.0/#54-range). To georeference a Manifest or Range, multiple Georeference Annotations are needed, one for each Canvas or Image Service in the Manifest or Range.
 
 ### 2.2 Georeferencing Process
 
 The process of georeferencing consists of the following steps:
 
-1. Selecting a IIIF resource. When a resource depicts multiple maps (such as inset maps) or when the resource contains non-cartographic parts (such as legends or borders), a polygonal selector is used to select the region of the resource that contains a single map. The shape of a polygonal selector can vary from a simple rectangle to a more complex polygon. This step is called _cropping_ or _masking_ in other georeferencing software.
+1. Selecting a IIIF resource. When a resource depicts multiple maps (such as inset maps) or when the resource contains non-cartographic parts (such as legends or borders), a polygonal selector is used to select a region of the resource that corresponds to a single map.<sup title="use multiple Georeference Annotations, one for each individual map, to select the multitude of maps on a single IIIF resource.">ⓘ</sup> The shape of a polygonal selector can vary from a simple rectangle to a more complex polygon. This step is called _cropping_ or _masking_ in other georeferencing software.
 2. Defining a mapping between coordinates on the IIIF resource and corresponding geographic WGS84 coordinates. This mapping consists of pairs of resource coordinates and geographic coordinates. Each pair of coordinates is called a Ground Control Point (GCP). At least three GCPs are needed to enable clients to warp a map.
 3. Optionally, a preferred transformation algorithm is defined that clients can use to turn the discrete set of GCPs into a function that interpolates any of the IIIF resource coordinates to geographic coordinates, and vice versa.
 
@@ -73,41 +73,43 @@ In Georeference Annotations, these steps are encoded as follows:
 | Data                     | Georeference Annotation                                             |
 |--------------------------|---------------------------------------------------------------------|
 | Resource and selector    | IIIF Presentation API Canvas or Image API Image Service with an optional [SVG Selector](https://www.w3.org/TR/annotation-model/#svg-selector) or [Image API Selector](https://iiif.io/api/annex/openannotation/#iiif-image-api-selector) |
-| GCPs                     | A GeoJSON Feature Collection where each GCP is stored as a GeoJSON Feature with a Point geometry and a `resourceCoords` property in the Feature's `properties` object |
+| GCPs                     | A GeoJSON Feature Collection where each GCP is stored as a GeoJSON Feature with Point geometry and a `resourceCoords` property in the Feature's `properties` object |
 | Transformation algorithm | A `transformation` property defined on the GeoJSON Feature Collection that holds the GCPs |
 {: .api-table #table-critical-data-for-georeferencing}
 
 __Target Projection__<br/>
-Please note that, at this time, the Georeference Extension does not provide a property for specifying which geographic projection should be targeted when warping a IIIF resource. Most commonly, IIIF resources will be warped to the [WGS84 / Pseudo Mercator](https://epsg.io/?q=3857) projection (EPSG:3857), which is the current *de facto* standard for web mapping interfaces. Targeting another projection, even while using the same set of GCPs, will produce a different result. A property for specifying a target projection may be added in future versions of the extension.
+Please note that the Georeference Extension does not provide a property for specifying which geographic projection should be targeted when warping a IIIF resource. Most commonly, IIIF resources will be warped to the [WGS84 / Pseudo Mercator](https://epsg.io/?q=3857) projection (EPSG:3857), which is the current *de facto* standard for web mapping interfaces. Targeting another projection, even while using the same set of GCPs, will produce a different result. A property for specifying a target projection may be added in future versions of the extension.
 {: .note}
 
 ## 3. Web Annotations for Georeferencing
 
-The combined information described in Section 2 is stored in a Georeference Annotation which is modelled on the Web Annotation Data Model. This section details the structure of a Georeference Annotation and its relationship to the IIIF Presentation API and Image API. It includes examples of the different properties and options.
+The combined information described in Section 2 is stored in a Georeference Annotation using the [Web Annotation Data Model](https://www.w3.org/TR/annotation-model/). This section details the structure of a Georeference Annotation and its relationship to the IIIF Presentation API and Image API. It includes examples of the different properties and options.
 
 ### 3.1 Embedded vs. Referenced Annotations
 
-Georeference Annotations can be included in a IIIF Presentation API response as part of an [Annotation Page](https://iiif.io/api/presentation/3.0/#annotations) under the `annotations` property of a Canvas. Alternatively, Georeference Annotations can exist independent of the targeted IIIF resource.
+Georeference Annotations can be included in a IIIF Presentation API response as part of an [Annotation Page](https://iiif.io/api/presentation/3.0/#annotations) under the `annotations` property of a Canvas. Alternatively, Georeference Annotations can exist independent of their targeted IIIF resources at their URI `id`.
 
-For Georeference Annotations included in a Canvas, implementers _MUST_ have at least one Annotation Page in the `annotations` property of the targeted Canvas. Implementers have the option to [reference or embed](https://iiif.io/api/presentation/3.0/#12-terminology) those Annotation Pages. For the purposes of this extension, implementers _SHOULD_ embed the Annotation Pages in the `annotations` property as opposed to referencing them. See the Cookbook entry [Embedded or referenced Annotations](https://iiif.io/api/cookbook/recipe/0269-embedded-or-referenced-annotations/) for a close look at the difference.
+For Georeference Annotations included in a Canvas, implementers _MUST_ have at least one Annotation Page in the `annotations` property of the targeted Canvas. Implementers have the option to [reference or embed](https://iiif.io/api/presentation/3.0/#12-terminology) those Annotation Pages. For the purposes of this extension, implementers _SHOULD_ embed the Annotation Pages in the `annotations` property as opposed to referencing them.  See the Cookbook entry [Embedded or referenced Annotations](https://iiif.io/api/cookbook/recipe/0269-embedded-or-referenced-annotations/) for a close look at the difference.
 
-Embedding resources reduces the need to make HTTP calls. It also ensures the availability of resources when URIs do not resolve. In those cases it would otherwise not be possible to display or use those resources in client applications.
+__Why should you embed?__<br/>
+Embedding resources reduces the need to make HTTP calls. It also ensures the availability of resources when URIs do not resolve. In those cases it would otherwise not be possible to display or use those resources in client applications. If you are certain the resources you are referencing will consistently resolve to the same object you plan to embed then you can move past this suggestion.
+{: .note}
 
 ### 3.2 Georeference Annotation `motivation`
 
 The `motivation` property declares the reason for creating the Georeference Annotation. The `motivation` property _SHOULD_ be included on all Georeference Annotations and when included it _MUST_ have the value `georeferencing`.
 
-Note that the [linked data context]({{ site.api_url | absolute_url }}/extension/georef/1/context.json) provided with this document includes the formal linked data 1.1 motivation extension, and the [vocabulary]({{ site.api_url | absolute_url }}/extension/georef/vocab/georef-terms.md) provided with this document contains the formal vocabulary for the "georeferencing" motivation discussed above.
+The [linked data context]({{ site.api_url | absolute_url }}/extension/georef/1/context.json) provided with this document includes the formal linked data 1.1 motivation extension, and the [vocabulary]({{ site.api_url | absolute_url }}/extension/georef/vocab/georef-terms.md) provided with this document contains the formal vocabulary for the "georeferencing" motivation discussed above.
 
 ### 3.3 Georeference Annotation `target`
 
 The `target` property describes the resource that the Georeference Annotation applies to. The value for `target` _MUST_ either be a single and full IIIF resource, or a single region within a IIIF resource represented as a [Specific Resource](https://www.w3.org/TR/annotation-model/#specific-resources).
 
-For Georeference Annotations embedded in the `annotations` property of a Canvas, the `target` _MUST_ be the Canvas URI. When the desired target is a part of a Canvas represented by a Specific Resource, the `source` _MUST_ be the Canvas URI. For Georeference Annotations that are external to the IIIF resource they target, implementers _SHOULD_ embed the IIIF resource in the `target` property instead of referencing it.
+For Georeference Annotations embedded in the `annotations` property of a Canvas, the `target` _MUST_ be the Canvas URI. When the desired target is a part of a Canvas represented by a Specific Resource, the `source` _MUST_ be the Canvas URI. For Georeference Annotations that are external to the IIIF resource they target, implementers SHOULD_ embed the IIIF resource in the `target` property instead of referencing it.
 
-Clients processing the georeferencing information require the original height and width of the resources in order to have the proper aspect ratios. Implementers _SHOULD_ add the `height` and `width` properties to their embedded resources for consistency.
+Clients processing the georeferencing information require the original height and width of the resources to have the proper aspect ratios. Implementers _SHOULD_ add the `height` and `width` properties to their embedded resources for consistency.
 
-Sometimes the targeted resource exists within a parent resource, such as a targeted Canvas that exists embedded in some Manifest. In these cases, it is important to maintain the link between them to access useful contextual information. Implementers _MAY_ use the `partOf` property to reference the parent resource.
+Sometimes the targeted resource exists within a parent resource, such as a targeted Canvas that exists embedded in some Manifest. In these cases, it is important to maintain the link between them to access useful contextual information. Implementers _MAY_ use the [`partOf` property](https://iiif.io/api/presentation/3.0/#partof) to reference the parent resource.
 
 #### 3.3.1 Targeting the Full Resource
 
@@ -185,9 +187,9 @@ More Georeference Annotation examples with robust implementation guidance will b
 
 The `body` of a Georeference Annotation contains the geospatial information about the resource that is referenced or embedded in the `target` property. For the purposes of this extension the `body` contains the GCPs. The value for `body` _MUST_ be a GeoJSON Feature Collection. The Feature Collection _MUST_ only contain Features with [Point](https://www.rfc-editor.org/rfc/rfc7946#section-3.1.2) geometries and _SHOULD_ contain at least three Point Features.
 
-All commonly used transformation algorithms (including the ones described below) that are used to warp images require at least three GCPs. Algorithms exist that only need two GCPs, but they require information about the coordinate reference system (CRS) of the map. This specification does not support adding information about a map's CRS, as explained in [Section 1.1](#11-objectives-and-scope).
+All commonly used transformation algorithms (including the ones described below) that are used to warp images require at least three GCPs. Algorithms exist that only need two GCPs, but they require information about the coordinate reference system (CRS) of the map. This extension does not support adding information about a map's CRS, as explained in [Section 1.1](#11-objectives-and-scope).
 
-Still, a Georeference Annotation that contains less than three GCPs is valid. These annotations hold geospatial information that can be used in geospatial databases or GIS applications. Supporting annotations with less than three GCPs is also useful for crowdsourcing; incomplete annotations can be finished by someone else while intermediary results still comply to the specification.
+Still, a Georeference Annotation that contains less than three GCPs is valid. Such Georeference Annotations hold geospatial information that can be used in geospatial databases or GIS applications. In crowdsourcing scenarios "incomplete" Georeference Annotations can be finished by someone else while intermediary results still comply with this extension.
 
 An example of the Georeference Annotation `body`:
 
@@ -209,7 +211,7 @@ An example of the Georeference Annotation `body`:
 
 ### 3.5 The `resourceCoords` Property
 
-The `resourceCoords` property is defined by this document in order to supply the coordinates from the IIIF resource together with the WGS84 `coordinates` in a Feature to form a single GCP. Each Feature in the Feature Collection _MUST_ have the `resourceCoords` property in the `properties` property. The value is an array representing a resource coordinate at (x, y) and _MUST_ be exactly in that order.
+The `resourceCoords` property is defined by this document in order to supply the coordinates from the IIIF resource and the WGS84 `coordinates` in a Feature together to form a single GCP. Each Feature in the Feature Collection _MUST_ have the `resourceCoords` property in the `properties` property. The value is an array representing a resource coordinate at (x, y) and _MUST_ be exactly in that order.
 
 An example of a Feature with the `resourceCoords` property:
 
@@ -228,7 +230,7 @@ An example of a Feature with the `resourceCoords` property:
 ```
 
 __Coordinate System of GCP Resource Coordinates__<br/>
-The `resourceCoords` property uses the same cartesian coordinate system as the targeted IIIF resource. When this is a IIIF Presentation API Canvas or Image API Image Service (either the full resource or using an SVG Selector), this means that `resourceCoords` value (x, y) corresponds to coordinates (x, y) on the resource. However, when an [Image API Selector](https://iiif.io/api/annex/openannotation/#iiif-image-api-selector) is used, this means that `resourceCoords` value (x, y) corresponds to the _translated_, _resized_ and _rotated_ coordinates according to the Selector's [region](https://iiif.io/api/image/3.0/#41-region), [size](https://iiif.io/api/image/3.0/#42-size) and [rotation](https://iiif.io/api/image/3.0/#43-rotation) parameters.
+The `resourceCoords` property uses the same cartesian coordinate system as the targeted IIIF resource. When the Georeference Annotation's targeted resource is the full resource or a selected region of the resource via an SVG selector, the `resourceCoords` value (x, y) corresponds to coordinates (x, y) of that resource. However, when an [Image API Selector](https://iiif.io/api/annex/openannotation/#iiif-image-api-selector) is used instead of an SVG Selector the `resourceCoords` value (x, y) corresponds to the _translated_, _resized_ and _rotated_ coordinates according to the Selector's [region](https://iiif.io/api/image/3.0/#41-region), [size](https://iiif.io/api/image/3.0/#42-size) and [rotation](https://iiif.io/api/image/3.0/#43-rotation) parameters.
 {: .note}
 
 ### 3.6 The `transformation` Property
@@ -255,7 +257,7 @@ The table below describes the different possible `order` values for the `polynom
 | `2`   | 2nd order (quadratic) polynomial transformation |
 | `3`   | 3nd order (cubic) polynomial transformation     |
 
-Other properties within `options`, including other transformation types not defined in this document, _SHOULD_ be described either by [registered IIIF API extensions](https://iiif.io/api/extension/) or [local linked data contexts](https://www.w3.org/TR/json-ld11/#dfn-local-context). If a client is not able to process properties it _MUST_ ignore them.
+Other properties within `options`, including other transformation types not defined in this document, _SHOULD_ be described either by [registered IIIF API extensions](https://iiif.io/api/extension/) or [local linked data contexts](https://www.w3.org/TR/json-ld11/#dfn-local-context). If a client is not able to process properties then it _MUST_ ignore them.
 
 Example of a `transformation` JSON object:
 
@@ -499,7 +501,7 @@ GCP-based image georeferencing is a common task that's available in many GIS app
 - [QGIS](https://docs.qgis.org/3.22/en/docs/user_manual/working_with_raster/georeferencer.html)
 - [Map Warper](https://github.com/timwaters/mapwarper)
 
-Note that none of the tools listed above currently support georeferencing IIIF resources using Georeference Annotations.
+This list is not a complete list and the tools listed above do not support georeferencing IIIF resources using Georeference Annotations.
 
 ### B. Acknowledgements
 

--- a/source/extension/georef/index.md
+++ b/source/extension/georef/index.md
@@ -87,7 +87,7 @@ The combined information described in Section 2 is stored in a Georeference Anno
 
 ### 3.1 Embedded vs. Referenced Annotations
 
-Georeference Annotations can be included in a IIIF Presentation API response as part of an [Annotation Page](https://iiif.io/api/presentation/3.0/#annotations) under the `annotations` property of a Canvas. Alternatively, Georeference Annotations can exist independent of their targeted IIIF resources at their URI `id`.
+Georeference Annotations can be included in a IIIF Presentation API response as part of an [Annotation Page](https://iiif.io/api/presentation/3.0/#annotations) under the `annotations` property of a Canvas. Alternatively, Georeference Annotations can exist independent of their targeted IIIF resource and can be retrieved by resolving their URI `id`.
 
 For Georeference Annotations included in a Canvas, implementers _MUST_ have at least one Annotation Page in the `annotations` property of the targeted Canvas. Implementers have the option to [reference or embed](https://iiif.io/api/presentation/3.0/#12-terminology) those Annotation Pages. For the purposes of this extension, implementers _SHOULD_ embed the Annotation Pages in the `annotations` property as opposed to referencing them.  See the Cookbook entry [Embedded or referenced Annotations](https://iiif.io/api/cookbook/recipe/0269-embedded-or-referenced-annotations/) for a close look at the difference.
 
@@ -105,7 +105,7 @@ The [linked data context]({{ site.api_url | absolute_url }}/extension/georef/1/c
 
 The `target` property describes the resource that the Georeference Annotation applies to. The value for `target` _MUST_ either be a single and full IIIF resource, or a single region within a IIIF resource represented as a [Specific Resource](https://www.w3.org/TR/annotation-model/#specific-resources).
 
-For Georeference Annotations embedded in the `annotations` property of a Canvas, the `target` _MUST_ be the Canvas URI. When the desired target is a part of a Canvas represented by a Specific Resource, the `source` _MUST_ be the Canvas URI. For Georeference Annotations that are external to the IIIF resource they target, implementers SHOULD_ embed the IIIF resource in the `target` property instead of referencing it.
+For Georeference Annotations embedded in the `annotations` property of a Canvas, the `target` _MUST_ be the Canvas URI. When the desired target is a part of a Canvas represented by a Specific Resource, the `source` _MUST_ be the Canvas URI. For Georeference Annotations that are external to the IIIF resource they target, implementers _SHOULD_ embed the IIIF resource in the `target` property instead of referencing it.
 
 Clients processing the georeferencing information require the original height and width of the resources to have the proper aspect ratios. Implementers _SHOULD_ add the `height` and `width` properties to their embedded resources for consistency.
 

--- a/source/extension/georef/index.md
+++ b/source/extension/georef/index.md
@@ -497,11 +497,7 @@ Consult the [Linked Data Context and Extensions section of IIIF Presentation API
 
 This extension was produced by the IIIF Maps Community Group and IIIF Maps Technical Specification Group. Of course, assistance came from many branches of the IIIF Community. We thank everyone for their time and perseverance given to ensure this extension is as useful as possible.
 
-<<<<<<< HEAD
-A grant of [Stichting Pica](https://www.stichtingpica.nl) for further development of the [Allmaps Viewer](https://viewer.allmaps.org) made possible the completion of this extension.
-=======
 A grant from [Stichting Pica](https://www.stichtingpica.nl) for the further development of [Allmaps Viewer](https://viewer.allmaps.org) made the completion of this extension possible.
->>>>>>> georef
 
 ### B. Change Log
 

--- a/source/extension/index.md
+++ b/source/extension/index.md
@@ -64,6 +64,7 @@ This table summarizes the known extensions available, for use with the [Presenta
 | ------------------------------ |
 | [navPlace Extension][navPlace] |
 | [Text Granularity Extension][text-granularity] |
+| [Georeference Extension][georeference] |
 {: .api-table}
 
 

--- a/source/index.md
+++ b/source/index.md
@@ -40,12 +40,13 @@ We welcome feedback on all IIIF Specifications. Please send any feedback to [iii
 
 Please see the [Registry of Extensions][registry] for full details on how extensions work and the process for creating them.
 
-Currently, there are two formally published extensions available for use with the Presentation API.
+Currently, there are three formally published extensions available for use with the Presentation API.
 
 | Presentation API Extensions    | Description |
 | ------------------------------ | ----------- |
 | [navPlace Extension][navPlace] | This IIIF Presentation 3 API extension defines a new property, navPlace, which is defined by earthbound geographic coordinates in the form of GeoJSON-LD. |
 | [Text Granularity Extension][text-granularity] | This extension recommends a pattern for indicating the level of text granularity for an annotation related to optical character recognition (OCR) software, manual transcription, and existing digitized text. |
+| [Georeference Extension][georeference] | This extension leverages Web Annotations to provide a pattern for georeferencing IIIF Presentation 3 API Canvases as well as images served through the IIIF Image API. |
 {: .api-table style="max-width: 780px;"}
 
 


### PR DESCRIPTION
Most drastic changes were 

- add the "note" formatting for the sentence about why we suggest you embed.
- add a <sup title="use multiple Georeference Annotations, one for each individual map, to select the multitude of maps on a single IIIF resource.">ⓘ</sup> to section 2.2 to help clarify about what to do for multiple maps.
- replace certain instances of "in order to" with the abbreviated "to".
- replace instances of "specification" to "extension" when referring to the Georeference Extension.
- replace instances of "GeoJSON specification" to "GeoJSON format"

There were other small wording changes, all of which can be seen in the diff.



